### PR TITLE
Fixing vpc_security_group_ids field for TF 12

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "this" {
 
   snapshot_identifier = var.snapshot_identifier
 
-  vpc_security_group_ids = [var.vpc_security_group_ids]
+  vpc_security_group_ids = var.vpc_security_group_ids
   db_subnet_group_name   = var.db_subnet_group_name
   parameter_group_name   = var.parameter_group_name
   option_group_name      = var.option_group_name


### PR DESCRIPTION
Quick fix for sg_ids. TF 12 doesn't coerce lists the same way as 11...